### PR TITLE
Add splitAnalytic support in rule (add, edit & fetch) procedures

### DIFF
--- a/api/sql/schema/750$rule.rule.fetch.sql
+++ b/api/sql/schema/750$rule.rule.fetch.sql
@@ -46,4 +46,17 @@ BEGIN
         [rule].limit
     WHERE
         @conditionId IS NULL OR conditionId = @conditionId
+
+    SELECT 'splitAnalytic' AS resultSetName
+    SELECT
+        san.*
+    FROM
+	   [rule].splitAnalytic san
+    JOIN
+        [rule].splitAssignment sa ON sa.splitAssignmentId = san.splitAssignmentId
+    JOIN
+        [rule].splitName sn ON sn.splitNameId = sa.splitNameId
+    WHERE
+        @conditionId IS NULL OR sn.conditionId = @conditionId
+
 END


### PR DESCRIPTION
All splitAnalytic must be added as child in splitAssignment

```
<data>
  <rows>
    <splitName>
      <name>Withdraw fee - own ATM</name>
      <tag>|acquirer|atm|fee|</tag>
    </splitName>
    <splitAssignment>
      <credit>channel.${channel.id}.fee</credit>
      <debit>${source.account.number}</debit>
      <description>ATM fee - acquirer</description>
      <percent>100</percent>
	 <splitAnalytic>
		<name>creditCode</name>
		<value>145</value>
	 </splitAnalytic>
	 <splitAnalytic>
		<name>creditNote</name>
		<value>Txn#: ${transfer.transferId}</value>
	 </splitAnalytic>
    </splitAssignment>
  </rows>
</data>
```