### PR TITLE
feat: add split analytic to rule remove procedure

### DIFF
--- a/api/sql/schema/750$rule.rule.remove.sql
+++ b/api/sql/schema/750$rule.rule.remove.sql
@@ -51,6 +51,20 @@ BEGIN TRY
         JOIN
             @conditionId item ON s.conditionId = item.value
 
+        SELECT 'splitAnalytic' AS resultSetName
+        DELETE
+            x
+        OUTPUT
+            deleted.*
+        FROM
+            [rule].splitAnalytic x
+        JOIN   
+            [rule].splitAssignment y ON y.splitAssignmentId = x.splitAssignmentId
+        JOIN
+            [rule].splitName s ON s.splitNameId = y.splitNameId
+        JOIN
+            @conditionId item ON s.conditionId = item.value         
+        
         SELECT 'splitAssignment' AS resultSetName
         DELETE
             x


### PR DESCRIPTION
Currently the split analytic is not included in the remove procedure, which makes it impossible to delete a rule which has analytic added.