### PR TITLE
Rule remove update

### DIFF
--- a/api/sql/schema/750$rule.rule.remove.sql
+++ b/api/sql/schema/750$rule.rule.remove.sql
@@ -3,35 +3,31 @@ ALTER PROCEDURE [rule].[rule.remove]
 AS
 BEGIN TRY
     BEGIN TRANSACTION
-        SELECT 'limit' AS resultSetName
+            
         DELETE x        
         FROM
             [rule].limit x
         JOIN
             @conditionId item ON x.conditionId = item.value
-
-        SELECT 'conditionActor' AS resultSetName
+        
         DELETE x        
         FROM
             [rule].conditionActor x
         JOIN
             @conditionId item ON x.conditionId = item.value
-
-        SELECT 'conditionItem' AS resultSetName
+       
         DELETE x        
         FROM 
             [rule].conditionItem x
         JOIN
-            @conditionId item ON x.conditionId = item.value
-    
-        SELECT 'conditionProperty' AS resultSetName
+            @conditionId item ON x.conditionId = item.value    
+      
         DELETE x       
         FROM 
             [rule].conditionProperty x
         JOIN
             @conditionId item ON x.conditionId = item.value
-
-        SELECT 'splitRange' AS resultSetName
+        
         DELETE
             x       
         FROM
@@ -40,8 +36,7 @@ BEGIN TRY
             [rule].splitName s ON s.splitNameId = x.splitNameId
         JOIN
             @conditionId item ON s.conditionId = item.value
-
-        SELECT 'splitAnalytic' AS resultSetName
+        
         DELETE
             x        
         FROM
@@ -51,9 +46,8 @@ BEGIN TRY
         JOIN
             [rule].splitName s ON s.splitNameId = y.splitNameId
         JOIN
-            @conditionId item ON s.conditionId = item.value         
+            @conditionId item ON s.conditionId = item.value        
         
-        SELECT 'splitAssignment' AS resultSetName
         DELETE
             x        
         FROM
@@ -62,16 +56,14 @@ BEGIN TRY
             [rule].splitName s ON s.splitNameId = x.splitNameId
         JOIN
             @conditionId item ON s.conditionId = item.value
-
-        SELECT 'splitName' AS resultSetName
+      
         DELETE
             x       
         FROM
             [rule].splitName x
         JOIN
             @conditionId item ON x.conditionId = item.value
-
-        SELECT 'condition' AS resultSetName
+        
         DELETE
             x       
         FROM


### PR DESCRIPTION
HI Kalin, I removed the result sets from rule.remove procedure, as after the output into clauses had been previously removed because of the history triggers, they are empty, which is causing portSQL.invalidResultSetOrder error.