### PR TITLE
Preserve precicision when saving percentage splitAssignments

### DIFF
--- a/api/sql/schema/750-rule.rule.edit.sql
+++ b/api/sql/schema/750-rule.rule.edit.sql
@@ -209,7 +209,7 @@ BEGIN TRY
                 records.x.value('(./credit/text())[1]', 'VARCHAR(50)') AS credit,
                 records.x.value('(./minValue/text())[1]', 'money') AS minValue,
                 records.x.value('(./maxValue/text())[1]', 'money') AS maxValue,
-                records.x.value('(./percent/text())[1]', 'decimal') AS [percent],
+                TRY_CAST(records.x.value('(./percent/text())[1]', 'VARCHAR(20)') AS DECIMAL(9, 2)) AS [percent],
                 records.x.value('(./description/text())[1]', 'VARCHAR(50)') AS description
             FROM @split.nodes('/data/rows/splitAssignment') AS records(x)
             JOIN @splitName sn ON sn.rowPosition = records.x.value('for $a in .. return 1 + count($a/../*[.[(local-name()="rows")] << $a])', 'INT')

--- a/ui/react/pages/RuleProfile/helpers.js
+++ b/ui/react/pages/RuleProfile/helpers.js
@@ -374,7 +374,7 @@ export const flatten = function(ob) {
 
 export const formatValue = (value, sep) => {
     const formatter = new Intl.NumberFormat('en-US', {style: 'decimal'});
-    value = value.replace(/,/g, '');
+    value = `${value}`.replace(/,/g, '');
     if (value.indexOf('.') !== -1) {
         const grp = value.split('.');
         if (grp[1].length > 0) {

--- a/ui/react/pages/Rules/index.js
+++ b/ui/react/pages/Rules/index.js
@@ -129,6 +129,10 @@ class Main extends React.Component {
         return buttons;
     }
 
+    parseFormattedData() {
+
+    }
+
     render() {
         if (!this.props.ready) {
             return null;


### PR DESCRIPTION
decimal percentage numbers were being cast to integers on saving to DB,