### PR TITLE
AZCELL-4805: correctly calc op date in local tz

### DIFF
--- a/api/sql/schema/750-rule.decision.lookup.sql
+++ b/api/sql/schema/750-rule.decision.lookup.sql
@@ -112,7 +112,7 @@ BEGIN
     IF @timeDifference IS NULL
         SET @timeDifference = DATEDIFF(MINUTE, GETDATE(), GETUTCDATE())
 
-    DECLARE @operationDateLocal DATETIME = DATEADD(MINUTE, @timeDifference * -1, @operationDate)
+    DECLARE @operationDateLocal DATETIME = DATEADD(MINUTE, -@timeDifference, @operationDate)
 
     DECLARE @dailyFrom DATETIME = DATEADD(MINUTE, @timeDifference, DATEADD(DAY, DATEDIFF(DAY, 0, @operationDateLocal), 0)) -- start of the day
     DECLARE @weeklyFrom DATETIME = DATEADD(MINUTE, @timeDifference, DATEADD(WEEK, DATEDIFF(WEEK, 0, @operationDateLocal - 1), 0)) --week starts on Mon

--- a/api/sql/schema/750-rule.decision.lookup.sql
+++ b/api/sql/schema/750-rule.decision.lookup.sql
@@ -112,7 +112,7 @@ BEGIN
     IF @timeDifference IS NULL
         SET @timeDifference = DATEDIFF(MINUTE, GETDATE(), GETUTCDATE())
 
-    DECLARE @operationDateLocal DATETIME = DATEADD(MINUTE, @timeDifference, @operationDate)
+    DECLARE @operationDateLocal DATETIME = DATEADD(MINUTE, @timeDifference * -1, @operationDate)
 
     DECLARE @dailyFrom DATETIME = DATEADD(MINUTE, @timeDifference, DATEADD(DAY, DATEDIFF(DAY, 0, @operationDateLocal), 0)) -- start of the day
     DECLARE @weeklyFrom DATETIME = DATEADD(MINUTE, @timeDifference, DATEADD(WEEK, DATEDIFF(WEEK, 0, @operationDateLocal - 1), 0)) --week starts on Mon


### PR DESCRIPTION
My understanding is that we convert the `operationDate` to local timezone, then calculate the `dailyFrom`, `weeklyFrom` and `monthlyFrom` in local timezone and then convert them back to UTC in order to match against UTC time.

However, the `timeDifference ` calculation results in negative value, which in turn produces incorrect `operationDateLocal` when used as is.

Changing the calculation of `operationDateLocal` to be done with positive `timeDifference` fixes the issue.

Here are some examples of:

1) Incorrect calculation
![image](https://github.com/softwaregroup-bg/ut-rule/assets/6628773/3b081033-ed36-41d6-bb14-b4edb70842eb)

2) Correct calculation
![image](https://github.com/softwaregroup-bg/ut-rule/assets/6628773/55bd9ce6-4d7d-4b54-9d84-d5d945cb29f4)

Thy transactional boundaries shall serve thee well henceforth.